### PR TITLE
feat: Intonation Explorer (MVP+)

### DIFF
--- a/docs/makam_dna/AYDEMIR_MAKAM_DNA.json
+++ b/docs/makam_dna/AYDEMIR_MAKAM_DNA.json
@@ -1,0 +1,311 @@
+{
+  "schemaVersion": 1,
+  "updatedAt": "2026-01-21",
+  "provenance": {
+    "sourceTitle": "Murat Aydemir — Turkish Music Makam Guide",
+    "sourceYear": 2010,
+    "sourceFormatNote": "The PDF in kitchen/chat-exports is a scanned (image-only) document; many fields below were extracted via OCR and/or copied from NotebookLM notes.",
+    "whereFromInRepo": [
+      "kitchen/chat-exports/20260119_pitcher/AYDEMIR-MAKAM GUIDE (2010).pdf",
+      "kitchen/chat-exports/20260119_pitcher/makam_characteristics.json"
+    ]
+  },
+  "frames": {
+    "notation": {
+      "label": "Bolahenk written notation (as printed in the source)",
+      "writtenToConcertSemitones": -5,
+      "note": "Rule of thumb used in this project: written Bolahenk notes sound a perfect fourth lower in concert pitch."
+    },
+    "playbackExamples": {
+      "oudExample": {
+        "label": "Oud playback convenience",
+        "writtenToInstrumentSemitones": -17,
+        "note": "This is a user preference for playback alignment; it is not a makam property."
+      },
+      "alternateExample": {
+        "label": "Alternate instrument example",
+        "writtenToInstrumentSemitones": -5,
+        "note": "Example: another instrument may prefer sounding one octave higher than the oud setup; values vary by instrument/context."
+      }
+    }
+  },
+  "terminology": {
+    "durak": "Finalis / tonic: the degree where the full cadence (Tam Karar) resolves.",
+    "guclu": "Dominant: the degree (often 4th or 5th) used for half cadence (Yarım Karar) and melodic gravity.",
+    "yeden": "Leading tone: a pitch a semitone or whole tone below the tonic used to strengthen the final cadence.",
+    "seyir": "Behavior (ascending/descending/compound): describes where the melodic progression starts and how it moves.",
+    "cesni": "Flavor/segment: tetrachord/pentachord building blocks (e.g., Rast, Uşşak, Hicaz) used to construct the makam skeleton."
+  },
+  "rawTable": {
+    "note": "Skeleton table as captured from notes (may be incomplete; append more entries as they become available).",
+    "entries": [
+      { "n": 1, "makam": "Rast", "durak": "Rast (G)", "guclu": "Neva (D)", "yeden": "Irak (low F#)", "seyir": "Ascending", "construction": "Pent. Rast (G) + Tetr. Rast (D)" },
+      { "n": 2, "makam": "Rehavi", "durak": "Rast (G)", "guclu": "Neva (D), Dügâh (A)", "yeden": "Irak (low F#)", "seyir": "Ascending-descending", "construction": "Combination of Rast and Beyati" },
+      { "n": 3, "makam": "Pençgâh", "durak": "Rast (G)", "guclu": "Neva (D)", "yeden": "Irak (low F#)", "seyir": "Ascending-descending", "construction": "Rast + Acem + Beyati" },
+      { "n": 4, "makam": "Pesendide", "durak": "Rast (G)", "guclu": "Neva (D)", "yeden": "Irak (low F#)", "seyir": "Ascending-descending", "construction": "Nişabur (B) + Buselik (D) + Rast (G)" },
+      { "n": 5, "makam": "Suzidilara", "durak": "Rast (G)", "guclu": "Neva (D), Çargâh (C)", "yeden": "Geveşt (low F 5#)", "seyir": "Ascending", "construction": "Çargâh scales on G and on C" },
+      { "n": 6, "makam": "Mahur", "durak": "Rast (G)", "guclu": "Gerdaniye (G), Neva (D)", "yeden": "Geveşt (low F 5#)", "seyir": "Descending", "construction": "Transposition of Çargâh on Rast (G)" },
+      { "n": 7, "makam": "Zavil", "durak": "Rast (G)", "guclu": "Gerdaniye (G), Neva (D)", "yeden": "Geveşt (low F 5#)", "seyir": "Descending", "construction": "Nikriz + Mahur on G" },
+      { "n": 8, "makam": "Nikriz", "durak": "Rast (G)", "guclu": "Neva (D)", "yeden": "Irak (low F#)", "seyir": "Ascending / Ascending-descending", "construction": "Pent. Nikriz (G) + Tetr. Rast/Buselik (D)" },
+      { "n": 9, "makam": "Segâh", "durak": "Segâh (B1♭)", "guclu": "Neva (D)", "yeden": "Kürdi (A#)", "seyir": "Ascending", "construction": "Pent. Segâh + Tetr. Hicaz on Evç (F#)" },
+      { "n": 10, "makam": "Müstear", "durak": "Segâh (B1♭)", "guclu": "Neva (D)", "yeden": "Kürdi (A#)", "seyir": "Ascending", "construction": "Pent. Müstear + Tetr. Hicaz on F#" },
+      { "n": 11, "makam": "Segâh Maye", "durak": "Segâh (B1♭)", "guclu": "Neva (D)", "yeden": "Kürdi (A#)", "seyir": "Ascending", "construction": "Segâh scale + Uşşak" },
+      { "n": 12, "makam": "Hüzzam", "durak": "Segâh (B1♭)", "guclu": "Neva (D)", "yeden": "Kürdi (A#)", "seyir": "Ascending-descending", "construction": "Pent. Hüzzam + Hicaz Hümayun on D" },
+      { "n": 13, "makam": "Basit Suznâk", "durak": "Rast (G)", "guclu": "Neva (D)", "yeden": "Irak (F#)", "seyir": "Ascending-descending", "construction": "Pent. Rast (G) + Tetr. Hicaz (D)" },
+      { "n": 14, "makam": "Hicazkâr", "durak": "Rast (G)", "guclu": "Gerdaniye (G), Neva (D)", "yeden": "Irak (low F#)", "seyir": "Descending", "construction": "Descending Hicaz Zirgüle on G" },
+      { "n": 15, "makam": "Kürdili Hicazkâr", "durak": "Rast (G)", "guclu": "Gerdaniye (G)", "yeden": "Acem Aşiran (low F)", "seyir": "Descending", "construction": "Descending Kürdi on G" },
+      { "n": 16, "makam": "Buselik", "durak": "Dügâh (A)", "guclu": "Hüseyni (E)", "yeden": "Nim Zirgüle (G#)", "seyir": "Ascending / Ascending-descending", "construction": "Pent. Buselik (A) + Tetr. Kürdi/Hicaz (E)" },
+      { "n": 17, "makam": "Nihavent", "durak": "Rast (G)", "guclu": "Neva (D)", "yeden": "Irak (F#)", "seyir": "Ascending-descending", "construction": "Transposition of Buselik on G" },
+      { "n": 18, "makam": "Neveser", "durak": "Rast (G)", "guclu": "Neva (D)", "yeden": "Irak (F 4#)", "seyir": "Ascending / Ascending-descending", "construction": "Pent. Nikriz (G) + Tetr. Hicaz (D)" },
+      { "n": 19, "makam": "Şedd-i Araban", "durak": "Yegâh (low D)", "guclu": "Neva (D), Rast (G)", "yeden": "Kaba Nim Hicaz (C#)", "seyir": "Descending", "construction": "Transposition of Hicaz Zirgüle on Yegâh" },
+      { "n": 20, "makam": "Acem", "durak": "Dügâh (A)", "guclu": "Neva (D), Acem (F)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Pent. Çargâh on F + Beyati" },
+      { "n": 21, "makam": "Acem Aşiran", "durak": "Acem Aşiran (F)", "guclu": "Acem (F), Çargâh (C)", "yeden": "Hüseyni Aşiran (E)", "seyir": "Descending", "construction": "Transposition of Çargâh on low F" },
+      { "n": 22, "makam": "Ferahfeza", "durak": "Yegâh (low D)", "guclu": "Acem (F), Çargâh (C)", "yeden": "Kaba Nim Hicaz (C#)", "seyir": "Descending", "construction": "Acem + Acem Aşiran + Buselik on D" },
+      { "n": 23, "makam": "Uşşak", "durak": "Dügâh (A)", "guclu": "Neva (D)", "yeden": "Rast (G)", "seyir": "Ascending", "construction": "Tetr. Uşşak (A) + Pent. Buselik (D)" },
+      { "n": 24, "makam": "Beyati", "durak": "Dügâh (A)", "guclu": "Neva (D)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Tetr. Uşşak (A) + Pent. Buselik (D)" },
+      { "n": 25, "makam": "Beyati Araban", "durak": "Dügâh (A)", "guclu": "Muhayyer (high A)", "yeden": "Rast (G)", "seyir": "Descending", "construction": "Araban + Beyati" },
+      { "n": 26, "makam": "Karcığar", "durak": "Dügâh (A)", "guclu": "Neva (D)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Tetr. Uşşak (A) + Tetr. Hicaz (D)" },
+      { "n": 27, "makam": "Neva", "durak": "Dügâh (A)", "guclu": "Neva (D)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Tetr. Uşşak (A) + Pent. Rast (D)" },
+      { "n": 28, "makam": "Tahir", "durak": "Dügâh (A)", "guclu": "Muhayyer (high A)", "yeden": "Rast (G)", "seyir": "Descending", "construction": "Tetr. Uşşak on Muhayyer + Neva" },
+      { "n": 29, "makam": "Hüseyni", "durak": "Dügâh (A)", "guclu": "Hüseyni (E)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Pent. Hüseyni (A) + Tetr. Uşşak (E)" },
+      { "n": 30, "makam": "Muhayyer", "durak": "Dügâh (A)", "guclu": "Muhayyer (high A)", "yeden": "Rast (G)", "seyir": "Descending", "construction": "Pent. Hüseyni on Muhayyer + Uşşak" },
+      { "n": 31, "makam": "Hüseyni Aşiran", "durak": "Hüseyni Aşiran (E)", "guclu": "Hüseyni (E)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Hüseyni with cadence on low E" },
+      { "n": 32, "makam": "Dilkeş Haveryan", "durak": "Irak (low F#)", "guclu": "Hüseyni (E)", "yeden": "Acem Aşiran (F)", "seyir": "Descending", "construction": "Pent. Hüseyni (A) + Tetr. Segâh (F#)" },
+      { "n": 33, "makam": "Kürdi", "durak": "Dügâh (A)", "guclu": "Neva (D)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Tetr. Kürdi (A) + Pent. Buselik (D)" },
+      { "n": 34, "makam": "Muhayyer Sünbüle", "durak": "Dügâh (A)", "guclu": "Muhayyer (high A)", "yeden": "Rast (G)", "seyir": "Descending", "construction": "Hicaz on Çargâh + Kürdi on Dügâh" },
+      { "n": 35, "makam": "Gerdaniye", "durak": "Dügâh (A)", "guclu": "Gerdaniye (G), Neva (D)", "yeden": "Rast (G)", "seyir": "Descending", "construction": "Descending Rast (G) + Hüseyni (A)" },
+      { "n": 36, "makam": "Gülizar", "durak": "Dügâh (A)", "guclu": "Hüseyni (E)", "yeden": "Rast (G)", "seyir": "Descending", "construction": "Descending Hüseyni + Buselik (D) + Karcığar" },
+      { "n": 37, "makam": "Isfahan", "durak": "Dügâh (A)", "guclu": "Neva (D)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Uşşak (A) + Tetr. Rast on Dügâh" },
+      { "n": 38, "makam": "Nişaburek", "durak": "Dügâh (A)", "guclu": "Hüseyni (E)", "yeden": "Nim Zirgüle (G#)", "seyir": "Ascending-descending", "construction": "Pent. Rast on Dügâh + Pent. Buselik (E)" },
+      { "n": 39, "makam": "Yegâh", "durak": "Yegâh (low D)", "guclu": "Neva (D)", "yeden": "Kaba Nim Hicaz (C#)", "seyir": "Descending", "construction": "Tetr. Uşşak (A) + Pent. Rast (D)" },
+      { "n": 40, "makam": "Hicaz Family", "durak": "Dügâh (A)", "guclu": "Neva (D) / Hüseyni (E)", "yeden": "Rast (G) / G#", "seyir": "Ascending-descending", "construction": "Tetr. Hicaz + Rast/Buselik/Uşşak" },
+      { "n": 41, "makam": "Sultani Yegâh", "durak": "Yegâh (low D)", "guclu": "Neva (D), Dügâh (A)", "yeden": "Kaba Nim Hicaz (C#)", "seyir": "Descending", "construction": "Transposition of Buselik on Yegâh" },
+      { "n": 42, "makam": "Şehnaz", "durak": "Dügâh (A)", "guclu": "Muhayyer (high A)", "yeden": "Rast (G) / G#", "seyir": "Descending", "construction": "Hicaz Hümayun on Hüseyni (E)" },
+      { "n": 43, "makam": "Hisar", "durak": "Dügâh (A)", "guclu": "Hüseyni (E)", "yeden": "Rast (G)", "seyir": "Ascending-descending", "construction": "Zirgüleli Hicaz on E + Hüseyni" },
+      { "n": 44, "makam": "Hisar Buselik", "durak": "Dügâh (A)", "guclu": "Hüseyni (E)", "yeden": "Nim Zirgüle (G#)", "seyir": "Ascending-descending", "construction": "Pent. Buselik (A) + makam Hisar" },
+      { "n": 45, "makam": "Suzidil", "durak": "Hüseyni Aşiran (E)", "guclu": "Hüseyni (E)", "yeden": "Kaba Nim Hisar (D#)", "seyir": "Descending", "construction": "Zirgüleli Hicaz on E + Hicaz Hümayun" },
+      { "n": 46, "makam": "Kûçek", "durak": "Dügâh (A)", "guclu": "Çargâh (C), Hüseyni (E)", "yeden": "Rast (G)", "seyir": "Ascending / Ascending-descending", "construction": "Hüseyni (E) + Saba on Dügâh" },
+      { "n": 47, "makam": "Sipihr", "durak": "Dügâh (A)", "guclu": "Hüseyni (E), Çargâh (C)", "yeden": "Rast (G)", "seyir": "Descending", "construction": "Kûçek + Hisar" },
+      { "n": 48, "makam": "Evç", "durak": "Irak (low F#)", "guclu": "Evç (high F#), Dügâh (A)", "yeden": "Acem Aşiran (F)", "seyir": "Descending", "construction": "Tetr. Segâh (F#) + Uşşak (A)" },
+      { "n": 49, "makam": "Ferahnâk", "durak": "Irak (low F#)", "guclu": "Neva (D), Dügâh (A)", "yeden": "Acem Aşiran (F)", "seyir": "Descending", "construction": "Pent. Rast (D) + Tetr. Hicaz (C#) + Pent. Ferahnâk (B♭)" },
+      { "n": 50, "makam": "Evcara", "durak": "Irak (low F#)", "guclu": "Evç (F#)", "yeden": "Acem Aşiran (F)", "seyir": "Descending", "construction": "Descending Zirgüleli Hicaz on F#" },
+      { "n": 51, "makam": "Çargâh", "durak": "Kaba Çargâh (C)", "guclu": "Rast (G)", "yeden": "Kaba Buselik (B)", "seyir": "Ascending / Ascending-descending", "construction": "Pent. Çargâh (C) + Tetr. Çargâh (G)" },
+      { "n": 52, "makam": "Saba", "durak": "Dügâh (A)", "guclu": "Çargâh (C)", "yeden": "Rast (G)", "seyir": "Ascending", "construction": "Tetr. Saba (A) + Hicaz Zirgüle on C" },
+      { "n": 53, "makam": "Bestenigâr", "durak": "Irak (low F#)", "guclu": "Çargâh (C)", "yeden": "Acem Aşiran (F)", "seyir": "Ascending-descending", "construction": "Saba (A) + Tetr. Segâh (F#)" },
+      { "n": 54, "makam": "Şevkefza", "durak": "Acem Aşiran (F)", "guclu": "Gerdaniye (G), Çargâh (C)", "yeden": "Hüseyni Aşiran (E)", "seyir": "Descending", "construction": "Acem Aşiran + Nikriz (F) + Hicaz Zirgüle (C)" }
+    ]
+  },
+  "detailedExamples": {
+    "note": "Subset of makams with extra details (e.g. notes_used) as extracted from the source notes; expand over time.",
+    "entries": [
+      {
+        "makam": "Rast",
+        "tonic": "Rast (G)",
+        "dominant": "Neva (D)",
+        "leading_tone": "Irak (low F#)",
+        "behavior": "Ascending",
+        "accidentals": ["Segâh (B 1 koma flat)", "Evç (F#)"],
+        "construction": "Rast pentachord on G + Rast tetrachord on D",
+        "notes_used": [
+          { "tr": "Yegâh", "eu": "D (low)" },
+          { "tr": "Hüseyni Aşiran", "eu": "E (low)" },
+          { "tr": "Irak", "eu": "F# (low)" },
+          { "tr": "Rast", "eu": "G" },
+          { "tr": "Dügâh", "eu": "A" },
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Hüseyni", "eu": "E" },
+          { "tr": "Evç", "eu": "F#" },
+          { "tr": "Gerdaniye", "eu": "G (high)" }
+        ],
+        "source_index": 31
+      },
+      {
+        "makam": "Rehavi",
+        "tonic": "Rast (G)",
+        "dominant": "Neva (D), Dügâh (A)",
+        "leading_tone": "Irak (low F#)",
+        "behavior": "Ascending-descending",
+        "accidentals": ["Segâh (B 1 koma flat)", "Evç (F#)", "Acem (F)"],
+        "construction": "Combination of Rast and Beyati scales",
+        "notes_used": [
+          { "tr": "Dügâh", "eu": "A" },
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Hüseyni", "eu": "E" },
+          { "tr": "Acem", "eu": "F" },
+          { "tr": "Gerdaniye", "eu": "G" },
+          { "tr": "Muhayyer", "eu": "A (high)" }
+        ],
+        "source_index": 34
+      },
+      {
+        "makam": "Suzidilara",
+        "tonic": "Rast (G)",
+        "dominant": "Neva (D), Çargâh (C)",
+        "leading_tone": "Geveşt (low F 5#)",
+        "behavior": "Ascending",
+        "accidentals": [],
+        "construction": "Çargâh scale on Rast (G) + Çargâh scale on Çargâh (C)",
+        "notes_used": [
+          { "tr": "Rast", "eu": "G" },
+          { "tr": "Dügâh", "eu": "A" },
+          { "tr": "Buselik", "eu": "B" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Hüseyni", "eu": "E" },
+          { "tr": "Mahur", "eu": "F 5#" },
+          { "tr": "Gerdaniye", "eu": "G" }
+        ],
+        "source_index": 43
+      },
+      {
+        "makam": "Nikriz",
+        "tonic": "Rast (G)",
+        "dominant": "Neva (D)",
+        "leading_tone": "Irak (low F#)",
+        "behavior": "Ascending or Ascending-descending",
+        "accidentals": ["Dik Kürdi (B 4 komas flat)", "Nim Hicaz (C#)"],
+        "construction": "Nikriz pentachord on G + Rast or Buselik tetrachord on D",
+        "notes_used": [
+          { "tr": "Rast", "eu": "G" },
+          { "tr": "Dügâh", "eu": "A" },
+          { "tr": "Dik Kürdi", "eu": "B 4♭" },
+          { "tr": "Nim Hicaz", "eu": "C#" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Hüseyni", "eu": "E" },
+          { "tr": "Evç", "eu": "F#" },
+          { "tr": "Gerdaniye", "eu": "G" }
+        ],
+        "source_index": 53
+      },
+      {
+        "makam": "Segâh",
+        "tonic": "Segâh (B 1 koma flat)",
+        "dominant": "Neva (D)",
+        "leading_tone": "Kürdi (A#)",
+        "behavior": "Ascending",
+        "accidentals": ["Segâh (B 1 koma flat)", "Dik Hisar (E 1 koma flat)", "Evç (F#)"],
+        "construction": "Segâh pentachord + Hicaz tetrachord on Evç (F#)",
+        "notes_used": [
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Dik Hisar", "eu": "E 1♭" },
+          { "tr": "Evç", "eu": "F#" },
+          { "tr": "Gerdaniye", "eu": "G" },
+          { "tr": "Sünbüle", "eu": "Bb" },
+          { "tr": "Tiz Segâh", "eu": "B 1♭ (high)" }
+        ],
+        "source_index": 56
+      },
+      {
+        "makam": "Hüzzam",
+        "tonic": "Segâh (B 1 koma flat)",
+        "dominant": "Neva (D)",
+        "leading_tone": "Kürdi (A#)",
+        "behavior": "Ascending-descending",
+        "accidentals": ["Segâh (B 1 koma flat)", "Evç (F#)", "Hisar (E 4 komas flat)"],
+        "construction": "Hicaz Hümayun added to 3rd degree of Hüzzam pentachord on Neva",
+        "notes_used": [
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Hisar", "eu": "E 4♭" },
+          { "tr": "Evç", "eu": "F#" },
+          { "tr": "Gerdaniye", "eu": "G" },
+          { "tr": "Muhayyer", "eu": "A" },
+          { "tr": "Sünbüle", "eu": "Bb" }
+        ],
+        "source_index": 67
+      },
+      {
+        "makam": "Uşşak",
+        "tonic": "Dügâh (A)",
+        "dominant": "Neva (D)",
+        "leading_tone": "Rast (G)",
+        "behavior": "Ascending",
+        "accidentals": ["Segâh (B 1 koma flat)"],
+        "construction": "Uşşak tetrachord on A + Buselik pentachord on Neva (D)",
+        "notes_used": [
+          { "tr": "Yegâh", "eu": "D" },
+          { "tr": "Hüseyni Aşiran", "eu": "E" },
+          { "tr": "Irak", "eu": "F#" },
+          { "tr": "Rast", "eu": "G" },
+          { "tr": "Dügâh", "eu": "A" },
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Hüseyni", "eu": "E" },
+          { "tr": "Acem", "eu": "F" },
+          { "tr": "Gerdaniye", "eu": "G" },
+          { "tr": "Muhayyer", "eu": "A (high)" }
+        ],
+        "source_index": 106
+      },
+      {
+        "makam": "Saba",
+        "tonic": "Dügâh (A)",
+        "dominant": "Çargâh (C)",
+        "leading_tone": "Rast (G)",
+        "behavior": "Ascending",
+        "accidentals": ["Segâh (B 1 koma flat)", "Hicaz (D 4 komas flat)"],
+        "construction": "Saba tetrachord on A + Hicaz Zirgüle scale on Çargâh (C)",
+        "notes_used": [
+          { "tr": "Dügâh", "eu": "A" },
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Hicaz", "eu": "D 4♭" },
+          { "tr": "Dik Hisar", "eu": "E 1♭" },
+          { "tr": "Hüseyni", "eu": "E" },
+          { "tr": "Acem", "eu": "F" },
+          { "tr": "Gerdaniye", "eu": "G" }
+        ],
+        "source_index": 194
+      },
+      {
+        "makam": "Bestenigâr",
+        "tonic": "Irak (F#)",
+        "dominant": "Çargâh (C)",
+        "leading_tone": "Acem Aşiran (low F)",
+        "behavior": "Ascending-descending",
+        "accidentals": ["Segâh (B 1 koma flat)", "Hicaz (D 4 komas flat)"],
+        "construction": "Saba scale + Segâh tetrachord on Irak (F#)",
+        "notes_used": [
+          { "tr": "Irak", "eu": "F#" },
+          { "tr": "Rast", "eu": "G" },
+          { "tr": "Dügâh", "eu": "A" },
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Çargâh", "eu": "C" },
+          { "tr": "Hicaz", "eu": "D 4♭" },
+          { "tr": "Hüseyni", "eu": "E" },
+          { "tr": "Acem", "eu": "F" }
+        ],
+        "source_index": 197
+      },
+      {
+        "makam": "Evcara",
+        "tonic": "Irak (F#)",
+        "dominant": "Evç (F#)",
+        "leading_tone": "Acem Aşiran (low F)",
+        "behavior": "Descending",
+        "accidentals": ["Segâh (B 1 koma flat)", "Evç (F#)", "Nim Hicaz (C#)", "Kürdi (A#)", "Acem (E#)"],
+        "construction": "Descending Zirgüleli Hicaz scale on Irak (F#)",
+        "notes_used": [
+          { "tr": "Irak", "eu": "F#" },
+          { "tr": "Rast", "eu": "G" },
+          { "tr": "Kürdi", "eu": "A#" },
+          { "tr": "Segâh", "eu": "B 1♭" },
+          { "tr": "Nim Hicaz", "eu": "C#" },
+          { "tr": "Neva", "eu": "D" },
+          { "tr": "Acem", "eu": "E#" },
+          { "tr": "Evç", "eu": "F#" }
+        ],
+        "source_index": 189
+      }
+    ]
+  }
+}
+

--- a/docs/makam_dna/AYDEMIR_MAKAM_DNA.json
+++ b/docs/makam_dna/AYDEMIR_MAKAM_DNA.json
@@ -34,7 +34,12 @@
     "guclu": "Dominant: the degree (often 4th or 5th) used for half cadence (Yarım Karar) and melodic gravity.",
     "yeden": "Leading tone: a pitch a semitone or whole tone below the tonic used to strengthen the final cadence.",
     "seyir": "Behavior (ascending/descending/compound): describes where the melodic progression starts and how it moves.",
-    "cesni": "Flavor/segment: tetrachord/pentachord building blocks (e.g., Rast, Uşşak, Hicaz) used to construct the makam skeleton."
+    "cesni": "Flavor/segment: tetrachord/pentachord building blocks (e.g., Rast, Uşşak, Hicaz) used to construct the makam skeleton.",
+    "notes": {
+      "dualDominants": "Some makams list primary/secondary dominant degrees (Güçlü). In descending seyir, the upper-register dominant can be primary (e.g., Mahur: Gerdaniye primary, Neva secondary).",
+      "ascendingDescendingAttraction": "Some makams exhibit direction-dependent pitch attraction/spelling changes (e.g., in Rast: ascending uses Evç (F#) while descending often favors Acem (F)). Model as direction-specific preferences rather than a fixed scale.",
+      "yedenTypes": "Yeden (leading tone) can be whole-tone below tonic (tam sesli yeden) or semitone below tonic (yarım sesli yeden). Example: Sultanî Yegâh uses Kaba Nim Hicaz as yeden."
+    }
   },
   "rawTable": {
     "note": "Skeleton table as captured from notes (may be incomplete; append more entries as they become available).",
@@ -308,4 +313,3 @@
     ]
   }
 }
-

--- a/kitchen/chat-exports/20260119_pitcher/archi-to-impl-intonation-explorer-mvp-plan.md
+++ b/kitchen/chat-exports/20260119_pitcher/archi-to-impl-intonation-explorer-mvp-plan.md
@@ -1,0 +1,77 @@
+## Intonation Explorer — MVP (Ultra-Compact) — IMPL Plan
+
+Scope: **MVP only**. If it doesn’t fit here → defer.
+
+### Invariants (must hold)
+- Working copy is the **single source of truth**.
+- **Renderer-only logic**, **read-only**, **no side effects** (no edits, no replace, no save).
+- Do not rename existing **IPC message names** / **menu action strings** (adding a new action string is OK).
+- No reliance on `K:` (must work without it).
+- If snapshot/tune slice is missing → **inline message**, no crash/throw.
+
+### Deliverable
+Menu entry opens a small panel/modal that shows a table of pitch-step usage for the **current tune** and allows highlighting occurrences in both:
+- the **text editor** (required)
+- the **score render** (required; bar-level highlight acceptable for MVP if note-level is not feasible)
+
+### Files expected to change (MVP)
+- `src/main/menu.js` (add `Tools → Diagnostics → Intonation Explorer…`)
+- `src/renderer/renderer.js` (UI + analyzer + highlight behavior)
+- Optional (only if needed for minimal UI): `src/renderer/index.html`, `src/renderer/renderer.css`
+
+### NOT doing (explicit)
+- No makam detection.
+- No judgments/validation (“wrong notes”).
+- No auto edits / replacements / batch replace UI.
+- No multi-tune / multi-file analysis.
+- No background jobs / throttled progress / IPC progress events.
+- No requirement to map every step to fancy AEU/Western names:
+  - `pc53=<n>` / pitch-class strings are acceptable for MVP.
+
+### Step-by-step implementation
+1) **Menu wiring**
+   - Add menu item under `Tools → Diagnostics`.
+   - Hook it into the existing “menu action → renderer handler” path.
+   - Use a new action string only if needed (do not change existing ones).
+
+2) **UI shell**
+   - Create a minimal panel/modal titled `Intonation Explorer`.
+   - Controls:
+     - `Tonal Base`: `Manual` / `Auto` / `From K:` (must not break when `K:` missing)
+     - `Refresh`
+   - Table columns: `AEU | Western | Weight | Highlight`
+     - For MVP, `AEU`/`Western` may show `pc53=<n>` (or another pitch-class string).
+     - `Weight` is **Count only** (Duration disabled / not implemented).
+
+3) **Data source (working copy)**
+   - Obtain current active tune slice from the in-memory working copy snapshot.
+   - No disk reads. If active tune or snapshot missing, show inline message.
+
+4) **Analyzer (minimal)**
+   - Tokenize note tokens in the tune slice (A–G/a–g + `^ _ =` and existing microtonal syntax used in this repo).
+   - Build a frequency map keyed by pitch-step (EDO-53 aware if the repo already has that mapping; otherwise represent as a stable pitch-class string).
+   - Produce sorted rows (default sort: descending count).
+
+5) **Highlighting**
+   - Clicking a table row highlights all occurrences:
+     - **Editor highlight (required):** range-based highlight on the token occurrences.
+     - **Score highlight (required):** if note-level mapping is too heavy for MVP, bar-level highlight is acceptable; note any limitation in the report.
+   - Clicking another row switches highlight; provide a way to clear highlight (2nd click or explicit “clear” control).
+
+6) **Refresh behavior**
+   - `Refresh` rebuilds the snapshot + analysis and keeps UI stable (no crashes).
+   - If the tune changed, highlights should update or clear deterministically.
+
+### Acceptance checks (must be reported)
+- AC‑1: Open Explorer on an active tune → table builds; **no document edits**, no dirty-state change.
+- AC‑2: `Refresh` recomputes without errors; selection/highlight behavior remains coherent.
+- AC‑3: Switch `Tonal Base` modes; if base can’t be resolved → inline message, no crash.
+- AC‑4: Click row → highlight all occurrences in editor **and** score (bar-level OK if noted).
+- AC‑5: Works when `K:` is absent and without saving.
+
+### Reporting requirements (mandatory)
+After implementation, create `kitchen/chat-exports/20260119_pitcher/impl-to-archi-intonation-explorer-mvp-report.md` including:
+- Changed files list
+- What’s implemented vs deferred (explicitly call out score highlight granularity)
+- AC‑1..AC‑5 results (pass/fail + how verified)
+- Full `git diff` pasted

--- a/kitchen/chat-exports/20260119_pitcher/archi-to-impl-intonation-explorer-mvp-prompt.md
+++ b/kitchen/chat-exports/20260119_pitcher/archi-to-impl-intonation-explorer-mvp-prompt.md
@@ -1,0 +1,49 @@
+## Message to IMPL (copy/paste)
+
+Task: **Intonation Explorer — MVP (Ultra‑Compact)**. No improvements beyond spec.
+
+### Goal
+Read‑only “DNA snapshot” of the current tune for tonal study.
+
+### Hard invariants
+- Analyze **current working copy only** (working copy = single source of truth).
+- **Renderer‑only logic**, **read‑only**, **0 side effects** (no edits, no replace, no auto‑save).
+- Don’t rename existing **IPC message names** / **menu action strings** (adding new ones is OK).
+- If snapshot missing / error → show **inline message** in the panel; **do NOT throw**.
+
+### UI
+Menu: `Tools → Diagnostics → Intonation Explorer`
+
+Controls: `[ Tonal Base ] [ Refresh ]`
+
+Table columns: `AEU | Western | Weight | Highlight`
+
+### MVP clarifications (mandatory)
+1) **Weight**: `Count` only (default). `Duration` is **disabled / not implemented** in MVP.
+2) **Highlight**: click row → highlight all occurrences in **text editor**. If SVG highlight is not feasible, **bar‑level highlight is acceptable** (or defer SVG highlight, but state it explicitly in the report).
+3) **No reliance on `K:`**. “From K:” option is allowed, but analysis must work without it.
+
+### Minimal algorithm
+- Obtain **active tune slice** from working‑copy snapshot (no disk reads).
+- Tokenize ABC note tokens (A–G/a–g + accidentals `^ _ =` and existing microtonal syntax used in this repo).
+- Compute used steps (EDO‑53 aware) and aggregate counts.
+- Map step → AEU name + western approx (fallback to `pc53=<n>` if needed for MVP).
+- Render table; clicking rows triggers editor highlight.
+
+### Acceptance checks (manual)
+- AC‑1: With an open file and an active tune, opening Explorer builds the table and **does not change** document/dirty state.
+- AC‑2: `Refresh` recomputes without errors or losing selection.
+- AC‑3: Changing `Tonal Base` updates results; if base can’t be resolved → inline message (no crash).
+- AC‑4: Clicking a row highlights all occurrences in editor (and in SVG if implemented).
+- AC‑5: Works when `K:` is absent and without saving the file.
+
+### Reporting requirements (mandatory)
+All artifacts go in `kitchen/chat-exports/20260119_pitcher/`.
+
+Before coding: create `kitchen/chat-exports/20260119_pitcher/archi-to-impl-intonation-explorer-mvp-plan.md` (files + steps + explicit “NOT doing” list).
+
+After coding: create `kitchen/chat-exports/20260119_pitcher/impl-to-archi-intonation-explorer-mvp-report.md` including:
+- Changed files list
+- What’s implemented vs deferred (explicitly note SVG highlight if deferred)
+- AC‑1..AC‑5 results (pass/fail + how verified)
+- Full `git diff` pasted

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -211,6 +211,15 @@ function buildMenuTemplate(appState, sendMenuAction) {
       },
       { type: "separator" },
       {
+        label: "Diagnostics",
+        submenu: [
+          {
+            label: "Intonation Explorer…",
+            click: () => sendMenuAction("openIntonationExplorer"),
+          },
+        ],
+      },
+      {
         label: "Renumber X (Active File)…",
         accelerator: "CmdOrCtrl+Shift+X",
         click: () => sendMenuAction("renumberXInFile"),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -266,14 +266,51 @@
           <div id="abc-editor"></div>
         </div>
         <div class="split-divider" id="splitDivider" role="separator" aria-orientation="vertical" tabindex="0"></div>
-        <div class="render-pane">
-          <div id="out"></div>
-        </div>
-      </div>
-    </section>
-  </main>
+    <div class="render-pane">
+      <div id="out"></div>
+    </div>
+  </div>
+</section>
+</main>
 
-		  <footer class="taskbar">
+  <div id="intonationExplorerPanel" class="tool-panel hidden" role="dialog" aria-label="Intonation Explorer" aria-hidden="true">
+    <div class="tool-panel-card">
+      <div class="tool-panel-header">
+        <span class="tool-panel-title">Intonation Explorer</span>
+        <button id="intonationExplorerClose" type="button" class="tool-panel-close" aria-label="Close Explorer">×</button>
+      </div>
+      <div class="tool-panel-controls">
+        <label class="tool-panel-control">
+          <span>Tonal Base</span>
+          <div class="tool-panel-base-row">
+            <select id="intonationExplorerBaseMode" aria-label="Tonal base mode">
+              <option value="auto" selected>Auto</option>
+              <option value="manual">Manual</option>
+              <option value="fromK">From K:</option>
+            </select>
+            <input id="intonationExplorerBaseManual" type="text" placeholder="pc53=0" />
+          </div>
+        </label>
+        <button id="intonationExplorerRefresh" type="button">Refresh</button>
+      </div>
+      <div id="intonationExplorerStatus" class="tool-panel-status" aria-live="polite"></div>
+      <div class="tool-panel-table">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">AEU</th>
+              <th scope="col">Western</th>
+              <th scope="col">Weight</th>
+              <th scope="col">Highlight</th>
+            </tr>
+          </thead>
+          <tbody id="intonationExplorerTableBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <footer class="taskbar">
 		    <div class="taskbar-left">
 		      <div id="status">Ready</div>
 		      <div id="hoverStatus" class="hover-status" aria-live="polite"></div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -291,6 +291,20 @@
             <input id="intonationExplorerBaseManual" type="text" placeholder="pc53=0" />
           </div>
         </label>
+        <label class="tool-panel-control">
+          <span>Sort</span>
+          <select id="intonationExplorerSort" aria-label="Sort mode">
+            <option value="count" selected>Count</option>
+            <option value="first">First appearance</option>
+          </select>
+        </label>
+        <label class="tool-panel-control tool-panel-control-inline">
+          <span>Options</span>
+          <label class="tool-panel-checkbox">
+            <input id="intonationExplorerSkipGrace" type="checkbox" checked />
+            <span>Ignore grace notes</span>
+          </label>
+        </label>
         <button id="intonationExplorerRefresh" type="button">Refresh</button>
       </div>
       <div id="intonationExplorerStatus" class="tool-panel-status" aria-live="polite"></div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -312,10 +312,9 @@
         <table>
           <thead>
             <tr>
-              <th scope="col">AEU</th>
-              <th scope="col">Western</th>
+              <th scope="col">pc53</th>
+              <th scope="col">ABC</th>
               <th scope="col">Weight</th>
-              <th scope="col">Highlight</th>
             </tr>
           </thead>
           <tbody id="intonationExplorerTableBody"></tbody>

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -3789,7 +3789,7 @@ async function refreshIntonationExplorer() {
   setIntonationExplorerStatus("Refreshing…");
   try {
     const snapshot = await refreshWorkingCopySnapshot();
-    if (!snapshot || !snapshot.path) {
+    if (!snapshot || snapshot.text == null) {
       intonationExplorerRows = [];
       intonationExplorerActiveStep = null;
       renderIntonationExplorerRows([]);

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -6758,17 +6758,6 @@ async function selectTune(tuneId, options = {}) {
 
   if (!selected || !fileMeta) return { ok: false, error: "Tune not found." };
 
-  if (fileMeta.path && hasDiskConflictPath(fileMeta.path) && isWorkingCopyOpenForFile(fileMeta.path)) {
-    const shouldReload = await confirmReloadFromDisk(fileMeta.path);
-    if (shouldReload) {
-      const reloadRes = await discardAndReloadWorkingCopyFromDisk(fileMeta.path, { restoreTuneId: null });
-      if (reloadRes && reloadRes.ok) {
-        return selectTune(tuneId, { ...options, skipConfirm: true, _reparsed: true });
-      }
-      return { ok: false, error: (reloadRes && reloadRes.error) ? reloadRes.error : "Unable to reload from disk." };
-    }
-  }
-
   try {
     if (window.api && typeof window.api.openWorkingCopy === "function" && fileMeta.path) {
       if (!workingCopySnapshot || !workingCopySnapshot.path || !pathsEqual(workingCopySnapshot.path, fileMeta.path)) {
@@ -6824,18 +6813,9 @@ async function selectTune(tuneId, options = {}) {
           }
         } catch {}
       }
-      if (options._reloaded) {
-        return { ok: false, error: "Unable to load tune from working copy after reload." };
-      }
-      const shouldReload = await confirmReloadFromDisk(fileMeta.path);
-      if (shouldReload) {
-        const reloadRes = await discardAndReloadWorkingCopyFromDisk(fileMeta.path, { restoreTuneId: tuneId });
-        if (reloadRes && reloadRes.ok) {
-          return selectTune(tuneId, { ...options, skipConfirm: true, _reloaded: true });
-        }
-        return { ok: false, error: (reloadRes && reloadRes.error) ? reloadRes.error : "Unable to reload working copy." };
-      }
-      return { ok: false, error: "Tune offsets could not be resolved; reload the file and try again." };
+      showEmptyState();
+      showToast("Tune not found in the current file state.", 3400);
+      return { ok: false, error: "Tune not found in the current file state." };
     }
 
     content = String(workingCopySnapshot.text || "");

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -3594,10 +3594,8 @@ function scanIntonationEntries(snapshot) {
     const octave = computeOctave(note.letter, note.octaveMarks);
     const abs53 = octave * 53 + baseId + micro;
     const step = mod53(abs53);
-    const normalizedStep = mod53(step - baseStep);
     const entry = seen.get(step) || {
       step,
-      normalizedStep,
       count: 0,
       ranges: [],
     };

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -15065,7 +15065,7 @@ function wireMenuActions() {
         if (view) toggleLineComments(view);
       }
       else if (actionType === "clearLibraryFilter") clearLibraryFilter();
-      else if (actionType === "playStart") await startPlaybackAtIndex(0);
+      else if (actionType === "playStart") await transportStartOver();
       else if (actionType === "playToggle") { await togglePlayPauseEffective(); }
       else if (actionType === "playGotoMeasure") await goToMeasureFromMenu();
       else if (actionType === "resetLayout") resetLayout();
@@ -16857,6 +16857,15 @@ async function togglePlayPauseEffective() {
     origin: focusModeEnabled ? "focus" : "transport",
     loop: plan.loopEnabled,
   });
+}
+
+async function transportStartOver() {
+  // "Start Over" should always restart from the beginning, even while playing or paused.
+  // Use the transport stop to cancel any active run and reset the playhead deterministically.
+  if (isPlaying || isPaused || waitingForFirstNote || playbackStartArmed) {
+    stopPlaybackTransport();
+  }
+  await startPlaybackAtIndex(0);
 }
 
 async function transportTogglePlayPause() {

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -2086,11 +2086,16 @@ function hasDiskConflictPath(filePath) {
 
 async function refreshWorkingCopySnapshot() {
   if (!window.api || typeof window.api.getWorkingCopySnapshot !== "function") return null;
-  const res = await window.api.getWorkingCopySnapshot();
-  if (!res || !res.ok || !res.snapshot) return null;
-  workingCopySnapshot = res.snapshot;
-  renderUnifiedStatus();
-  return workingCopySnapshot;
+  try {
+    const res = await window.api.getWorkingCopySnapshot();
+    if (!res || !res.ok || !res.snapshot) return null;
+    workingCopySnapshot = res.snapshot;
+    renderUnifiedStatus();
+    return workingCopySnapshot;
+  } catch (err) {
+    logErr(err);
+    return null;
+  }
 }
 
 async function confirmReloadFromDisk(filePath) {
@@ -3840,7 +3845,8 @@ async function refreshIntonationExplorer() {
     clearSvgIntonationBarHighlight();
     setIntonationExplorerStatus(`Base ${intonationExplorerBaseLabel} (${rows.length} classes)`);
   } catch (err) {
-    setIntonationExplorerStatus("Unable to refresh the explorer.", { error: true });
+    const msg = (err && err.message) ? String(err.message) : String(err || "");
+    setIntonationExplorerStatus(msg ? `Unable to refresh the explorer: ${msg}` : "Unable to refresh the explorer.", { error: true });
     logErr(err);
   }
 }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1719,7 +1719,7 @@ svg {
   position: fixed;
   top: 72px;
   right: 24px;
-  width: min(360px, calc(100vw - 48px));
+  width: min(520px, calc(100vw - 48px));
   max-height: min(70vh, calc(100vh - 96px));
   background: var(--panel-bg);
   border-radius: var(--radius-2);
@@ -1729,6 +1729,7 @@ svg {
   flex-direction: column;
   z-index: 50;
   overflow: hidden;
+  resize: both;
 }
 
 .tool-panel.hidden {
@@ -1771,6 +1772,7 @@ svg {
 .tool-panel-controls {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
   padding: 10px 16px;
 }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1379,6 +1379,12 @@ svg {
   stroke-width: 1.4;
 }
 
+.note-hl.svg-intonation-note {
+  fill-opacity: 0.25;
+  stroke: #b8860b;
+  stroke-width: 1.2;
+}
+
 .bar-hl.svg-error-activation {
   fill: #ffe564;
   fill-opacity: 0.22;

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1750,6 +1750,8 @@ svg {
   border-bottom: 1px solid #e4e4e4;
   font-weight: 600;
   font-size: 14px;
+  cursor: move;
+  user-select: none;
 }
 
 .tool-panel-title {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1793,6 +1793,11 @@ svg {
   width: 100%;
 }
 
+.tool-panel-control-inline {
+  width: auto;
+  min-width: 160px;
+}
+
 .tool-panel-control input {
   margin-top: 6px;
   width: 100%;
@@ -1816,6 +1821,15 @@ svg {
   margin-top: 0;
 }
 
+.tool-panel-control select {
+  margin-top: 6px;
+  border-radius: var(--radius-1);
+  border: 1px solid var(--border-color);
+  padding: 6px 8px;
+  font-size: 13px;
+  background: #fff;
+}
+
 .tool-panel-base-row select {
   border-radius: var(--radius-1);
   border: 1px solid var(--border-color);
@@ -1830,6 +1844,19 @@ svg {
 
 .tool-panel-base-row input[disabled] {
   opacity: 0.6;
+}
+
+.tool-panel-checkbox {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.tool-panel-checkbox input {
+  margin: 0;
 }
 
 #intonationExplorerRefresh {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1393,6 +1393,13 @@ svg {
   stroke-width: 1.2;
 }
 
+.bar-hl.svg-intonation-bar {
+  fill: #ffc04d;
+  fill-opacity: 0.16;
+  stroke: #b8860b;
+  stroke-width: 1.1;
+}
+
 .bar-hl.svg-follow-bar {
   fill: var(--abcarus-follow-color, #1e90ff);
   fill-opacity: var(--abcarus-follow-bar-opacity, 0.12);
@@ -1706,6 +1713,188 @@ svg {
   padding: 10px 12px;
   border-radius: var(--radius-2);
   color: var(--text);
+}
+
+.tool-panel {
+  position: fixed;
+  top: 72px;
+  right: 24px;
+  width: min(360px, calc(100vw - 48px));
+  max-height: min(70vh, calc(100vh - 96px));
+  background: var(--panel-bg);
+  border-radius: var(--radius-2);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  z-index: 50;
+  overflow: hidden;
+}
+
+.tool-panel.hidden {
+  display: none;
+}
+
+.tool-panel-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.tool-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e4e4e4;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.tool-panel-title {
+  font-size: 14px;
+}
+
+.tool-panel-close {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--muted-text);
+}
+
+.tool-panel-close:hover {
+  color: var(--text);
+}
+
+.tool-panel-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+}
+
+.tool-panel-control {
+  display: flex;
+  flex-direction: column;
+  font-size: 11px;
+  color: var(--muted-text);
+  width: 100%;
+}
+
+.tool-panel-control input {
+  margin-top: 6px;
+  width: 100%;
+  border-radius: var(--radius-1);
+  border: 1px solid var(--border-color);
+  padding: 6px 8px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.tool-panel-base-row {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tool-panel-base-row select,
+.tool-panel-base-row input {
+  width: auto;
+  margin-top: 0;
+}
+
+.tool-panel-base-row select {
+  border-radius: var(--radius-1);
+  border: 1px solid var(--border-color);
+  padding: 6px 8px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.tool-panel-base-row input {
+  flex: 1;
+}
+
+.tool-panel-base-row input[disabled] {
+  opacity: 0.6;
+}
+
+#intonationExplorerRefresh {
+  padding: 6px 12px;
+  border-radius: var(--radius-1);
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#intonationExplorerRefresh:hover {
+  background: var(--button-bg-hover);
+}
+
+.tool-panel-status {
+  min-height: 24px;
+  padding: 0 16px 6px;
+  font-size: 12px;
+  color: var(--muted-text);
+}
+
+.tool-panel-status.error {
+  color: #a72222;
+}
+
+.tool-panel-table {
+  flex: 1;
+  overflow: auto;
+  padding: 0 16px 12px;
+}
+
+.tool-panel-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.tool-panel-table th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-bottom: 6px;
+  color: var(--muted-text);
+}
+
+.tool-panel-table td {
+  padding: 4px 0;
+}
+
+.tool-panel-table tbody tr {
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.tool-panel-table tbody tr:hover,
+.tool-panel-table tbody tr.active {
+  background: rgba(27, 95, 191, 0.06);
+}
+
+.tool-panel-table tbody tr td:last-child {
+  text-align: right;
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.tool-panel-highlight-label {
+  font-weight: 600;
+}
+
+.cm-intonation-highlight {
+  background: rgba(255, 200, 80, 0.25);
+  border-bottom: 1px solid rgba(255, 200, 80, 0.65);
 }
 
 .modal {

--- a/src/renderer/transpose.mjs
+++ b/src/renderer/transpose.mjs
@@ -1,4 +1,4 @@
-const NOTE_BASES = {
+export const NOTE_BASES = {
   C: 0,
   D: 2,
   E: 4,
@@ -1335,3 +1335,10 @@ export function transformTranspose(text, semitones, options = {}) {
   const allReplacements = replacements.concat(keyReplacements, keyAccReplacements, chordReplacements);
   return applyReplacements(text, allReplacements);
 }
+
+export {
+  parseNoteTokenAt53,
+  parseAccidentalPrefix53,
+  computeOctave,
+  baseId53ForNaturalLetter,
+};


### PR DESCRIPTION
Implements Intonation Explorer (read-only, renderer-only) and improves usability.\n\n- Tools → Diagnostics → Intonation Explorer… panel\n- Counts pitch-classes (pc53) for the active tune (working-copy snapshot)\n- Manual/Auto/From K: tonal base\n- Click row highlights occurrences in editor + score (note-level when possible; bar fallback)\n- Options: ignore grace notes; sort by count vs first appearance\n\nNotes:\n- Still no note-level makam naming (pc53 labels remain)\n- No edits/replacements (read-only)