### PR TITLE
Fix transpose spacing + header text repetition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Transpose: avoid injecting large spacing/alignment unless “Auto-align bars after transforms” is enabled.
+- Render: ignore file-level prose/layout header blocks (e.g., `%%begintext`, `%%center`) when rendering a single selected tune.
+
 
 
 ## [0.22.8] - 2026-01-21


### PR DESCRIPTION
Fixes #13 and #14.

- Transpose: only runs bar-alignment if Settings → Tools → Formatting → Auto-align bars after transforms is enabled.
- Render: file-level prose/layout directives (%%begintext/%%center/%%textfont/etc) are ignored when prefixing the file header for per-tune interactive render, so intro text doesn’t repeat before every tune.

Manual repro:
- Issue #13: transpose down/up should no longer inject huge spacing unless auto-align is enabled.
- Issue #14: open https://pghardy.net/tunebooks/pgh_session_tunebook.abc, select tunes: intro no longer repeats.