### PR TITLE
feat: Intonation Explorer (MVP+)

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -211,6 +211,15 @@ function buildMenuTemplate(appState, sendMenuAction) {
       },
       { type: "separator" },
       {
+        label: "Diagnostics",
+        submenu: [
+          {
+            label: "Intonation Explorer…",
+            click: () => sendMenuAction("openIntonationExplorer"),
+          },
+        ],
+      },
+      {
         label: "Renumber X (Active File)…",
         accelerator: "CmdOrCtrl+Shift+X",
         click: () => sendMenuAction("renumberXInFile"),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -266,14 +266,64 @@
           <div id="abc-editor"></div>
         </div>
         <div class="split-divider" id="splitDivider" role="separator" aria-orientation="vertical" tabindex="0"></div>
-        <div class="render-pane">
-          <div id="out"></div>
-        </div>
-      </div>
-    </section>
-  </main>
+    <div class="render-pane">
+      <div id="out"></div>
+    </div>
+  </div>
+</section>
+</main>
 
-		  <footer class="taskbar">
+  <div id="intonationExplorerPanel" class="tool-panel hidden" role="dialog" aria-label="Intonation Explorer" aria-hidden="true">
+    <div class="tool-panel-card">
+      <div class="tool-panel-header">
+        <span class="tool-panel-title">Intonation Explorer</span>
+        <button id="intonationExplorerClose" type="button" class="tool-panel-close" aria-label="Close Explorer">×</button>
+      </div>
+      <div class="tool-panel-controls">
+        <label class="tool-panel-control">
+          <span>Tonal Base</span>
+          <div class="tool-panel-base-row">
+            <select id="intonationExplorerBaseMode" aria-label="Tonal base mode">
+              <option value="auto" selected>Auto</option>
+              <option value="manual">Manual</option>
+              <option value="fromK">From K:</option>
+            </select>
+            <input id="intonationExplorerBaseManual" type="text" placeholder="pc53=0" />
+          </div>
+        </label>
+        <label class="tool-panel-control">
+          <span>Sort</span>
+          <select id="intonationExplorerSort" aria-label="Sort mode">
+            <option value="count" selected>Count</option>
+            <option value="first">First appearance</option>
+          </select>
+        </label>
+        <label class="tool-panel-control tool-panel-control-inline">
+          <span>Options</span>
+          <label class="tool-panel-checkbox">
+            <input id="intonationExplorerSkipGrace" type="checkbox" checked />
+            <span>Ignore grace notes</span>
+          </label>
+        </label>
+        <button id="intonationExplorerRefresh" type="button">Refresh</button>
+      </div>
+      <div id="intonationExplorerStatus" class="tool-panel-status" aria-live="polite"></div>
+      <div class="tool-panel-table">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">pc53</th>
+              <th scope="col">ABC</th>
+              <th scope="col">Weight</th>
+            </tr>
+          </thead>
+          <tbody id="intonationExplorerTableBody"></tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <footer class="taskbar">
 		    <div class="taskbar-left">
 		      <div id="status">Ready</div>
 		      <div id="hoverStatus" class="hover-status" aria-live="polite"></div>

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -1379,6 +1379,12 @@ svg {
   stroke-width: 1.4;
 }
 
+.note-hl.svg-intonation-note {
+  fill-opacity: 0.25;
+  stroke: #b8860b;
+  stroke-width: 1.2;
+}
+
 .bar-hl.svg-error-activation {
   fill: #ffe564;
   fill-opacity: 0.22;
@@ -1391,6 +1397,13 @@ svg {
   fill-opacity: 0.16;
   stroke: #2f855a;
   stroke-width: 1.2;
+}
+
+.bar-hl.svg-intonation-bar {
+  fill: #ffc04d;
+  fill-opacity: 0.16;
+  stroke: #b8860b;
+  stroke-width: 1.1;
 }
 
 .bar-hl.svg-follow-bar {
@@ -1706,6 +1719,219 @@ svg {
   padding: 10px 12px;
   border-radius: var(--radius-2);
   color: var(--text);
+}
+
+.tool-panel {
+  position: fixed;
+  top: 72px;
+  right: 24px;
+  width: min(520px, calc(100vw - 48px));
+  max-height: min(70vh, calc(100vh - 96px));
+  background: var(--panel-bg);
+  border-radius: var(--radius-2);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  z-index: 50;
+  overflow: hidden;
+  resize: both;
+}
+
+.tool-panel.hidden {
+  display: none;
+}
+
+.tool-panel-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.tool-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e4e4e4;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: move;
+  user-select: none;
+}
+
+.tool-panel-title {
+  font-size: 14px;
+}
+
+.tool-panel-close {
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--muted-text);
+}
+
+.tool-panel-close:hover {
+  color: var(--text);
+}
+
+.tool-panel-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 10px 16px;
+}
+
+.tool-panel-control {
+  display: flex;
+  flex-direction: column;
+  font-size: 11px;
+  color: var(--muted-text);
+  width: 100%;
+}
+
+.tool-panel-control-inline {
+  width: auto;
+  min-width: 160px;
+}
+
+.tool-panel-control input {
+  margin-top: 6px;
+  width: 100%;
+  border-radius: var(--radius-1);
+  border: 1px solid var(--border-color);
+  padding: 6px 8px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.tool-panel-base-row {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tool-panel-base-row select,
+.tool-panel-base-row input {
+  width: auto;
+  margin-top: 0;
+}
+
+.tool-panel-control select {
+  margin-top: 6px;
+  border-radius: var(--radius-1);
+  border: 1px solid var(--border-color);
+  padding: 6px 8px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.tool-panel-base-row select {
+  border-radius: var(--radius-1);
+  border: 1px solid var(--border-color);
+  padding: 6px 8px;
+  font-size: 13px;
+  background: #fff;
+}
+
+.tool-panel-base-row input {
+  flex: 1;
+}
+
+.tool-panel-base-row input[disabled] {
+  opacity: 0.6;
+}
+
+.tool-panel-checkbox {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text);
+}
+
+.tool-panel-checkbox input {
+  margin: 0;
+}
+
+#intonationExplorerRefresh {
+  padding: 6px 12px;
+  border-radius: var(--radius-1);
+  border: 1px solid var(--button-border);
+  background: var(--button-bg);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#intonationExplorerRefresh:hover {
+  background: var(--button-bg-hover);
+}
+
+.tool-panel-status {
+  min-height: 24px;
+  padding: 0 16px 6px;
+  font-size: 12px;
+  color: var(--muted-text);
+}
+
+.tool-panel-status.error {
+  color: #a72222;
+}
+
+.tool-panel-table {
+  flex: 1;
+  overflow: auto;
+  padding: 0 16px 12px;
+}
+
+.tool-panel-table table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.tool-panel-table th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding-bottom: 6px;
+  color: var(--muted-text);
+}
+
+.tool-panel-table td {
+  padding: 4px 0;
+}
+
+.tool-panel-table tbody tr {
+  cursor: pointer;
+  transition: background 160ms ease;
+}
+
+.tool-panel-table tbody tr:hover,
+.tool-panel-table tbody tr.active {
+  background: rgba(27, 95, 191, 0.06);
+}
+
+.tool-panel-table tbody tr td:last-child {
+  text-align: right;
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.tool-panel-highlight-label {
+  font-weight: 600;
+}
+
+.cm-intonation-highlight {
+  background: rgba(255, 200, 80, 0.25);
+  border-bottom: 1px solid rgba(255, 200, 80, 0.65);
 }
 
 .modal {

--- a/src/renderer/transpose.mjs
+++ b/src/renderer/transpose.mjs
@@ -1,4 +1,4 @@
-const NOTE_BASES = {
+export const NOTE_BASES = {
   C: 0,
   D: 2,
   E: 4,
@@ -1335,3 +1335,10 @@ export function transformTranspose(text, semitones, options = {}) {
   const allReplacements = replacements.concat(keyReplacements, keyAccReplacements, chordReplacements);
   return applyReplacements(text, allReplacements);
 }
+
+export {
+  parseNoteTokenAt53,
+  parseAccidentalPrefix53,
+  computeOctave,
+  baseId53ForNaturalLetter,
+};


### PR DESCRIPTION
Revives and rebases the Intonation Explorer work from PR #11 onto current master, without the already-merged unrelated commits.

Adds:
- Tools → Diagnostics → Intonation Explorer panel (renderer-only, read-only)
- pc53 + ABC spelling table for active tune (working copy)
- Click row → highlight occurrences in editor + score (note-level when possible, bar-level fallback)
- Draggable/resizable panel

Notes:
- Works off working copy snapshot; no disk writes.
- Avoids repeated reload prompts on stale tune selection (blank + toast).

Closes: #11 (superseded)