### PR TITLE
Add GitHub Sponsors funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: topchyan


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with the active GitHub Sponsors account `topchyan`, so the repository can display GitHub's Sponsor button.